### PR TITLE
Fix Reset.h case not being respected

### DIFF
--- a/firmware/stepper_nano_zero/commands.cpp
+++ b/firmware/stepper_nano_zero/commands.cpp
@@ -4,7 +4,7 @@
 #include "stepper_controller.h"
 #include <stdlib.h>
 #include "nonvolatile.h"
-#include "reset.h"
+#include "Reset.h"
 #include "nzs.h"
 #include "ftoa.h"
 #include "board.h"


### PR DESCRIPTION
Prevent build failure on systems that are case-sensitive by default, e.g. Linux.
Tested on latest Arduino package for Debian 11 (1.8.13).